### PR TITLE
Adjust Swagger Responses for Missing Courses to Return 200 Status

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -182,6 +182,12 @@ paths:
                             title: Module 2
                           - module_id: 3
                             title: Module 3
+                noCourseFound:
+                  summary: No course found
+                  value:
+                    code: 200
+                    message: Course not found
+                    data: null
         '400':
           description: Bad Request
           content:
@@ -191,16 +197,6 @@ paths:
               example:
                 code: 400
                 message: Course ID must be a positive integer number
-                data: null
-        '404':
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CodeAndMessage'
-              example:
-                code: 404
-                message: Course not found
                 data: null
     patch:
       tags:
@@ -370,6 +366,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/GetOneCourseResponse'
               examples:
+                noCourseFound:
+                  summary: No course found
+                  description: Occurs if the id does not exist
+                  value:
+                    code: 200
+                    message: Course not found
+                    data: null
                 successForDefault:
                   summary: Success (default mode)
                   value:
@@ -476,16 +479,6 @@ paths:
                     code: 400
                     message: Discounted price is not applicable
                     data: null
-        '404':
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CodeAndMessage'
-              example:
-                code: 404
-                message: Course not found
-                data: null
         '409':
           description: Conflict
           content:
@@ -536,6 +529,12 @@ paths:
                     code: 200
                     message: Course successfully deleted!
                     data: null
+                noCourseFound:
+                  summary: No course found
+                  value:
+                    code: 200
+                    message: Course not found
+                    data: null
         '400':
           description: Bad Request
           content:
@@ -545,16 +544,6 @@ paths:
               example:
                 code: 400
                 message: Course ID must be a positive integer number
-                data: null
-        '404':
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CodeAndMessage'
-              example:
-                code: 404
-                message: Course not found
                 data: null
   /api/v1/course:
     post:


### PR DESCRIPTION
This pull request updates the `docs.yaml` file to modify the handling of "course not found" scenarios in the API documentation. The changes replace the `404 Not Found` response with a `200 OK` response that includes a specific `noCourseFound` example, ensuring consistent messaging across endpoints.

### Updates to "course not found" handling:

* Added a `noCourseFound` example under relevant endpoints, with a `200 OK` response that includes a message indicating "Course not found." This ensures a more descriptive response for scenarios where a course is not found. (`[[1]](diffhunk://#diff-f81a60f62c2dec95be2564eabd59ad6222cc8bd5330ac4b7bbbdeff3776e32feR185-R190)`, `[[2]](diffhunk://#diff-f81a60f62c2dec95be2564eabd59ad6222cc8bd5330ac4b7bbbdeff3776e32feR369-R375)`, `[[3]](diffhunk://#diff-f81a60f62c2dec95be2564eabd59ad6222cc8bd5330ac4b7bbbdeff3776e32feR532-R537)`)

* Removed the `404 Not Found` response and its associated schema and example from multiple endpoints, replacing it with the new `noCourseFound` example. (`[[1]](diffhunk://#diff-f81a60f62c2dec95be2564eabd59ad6222cc8bd5330ac4b7bbbdeff3776e32feL195-L204)`, `[[2]](diffhunk://#diff-f81a60f62c2dec95be2564eabd59ad6222cc8bd5330ac4b7bbbdeff3776e32feL479-L488)`, `[[3]](diffhunk://#diff-f81a60f62c2dec95be2564eabd59ad6222cc8bd5330ac4b7bbbdeff3776e32feL549-L558)`)